### PR TITLE
Remove link to Google+

### DIFF
--- a/_includes/page.html
+++ b/_includes/page.html
@@ -23,7 +23,6 @@
       {% if page.date %}
       <span id="pub-date">Published on {{ page.date | date_to_string }}</span> <span class="separator">&bull;</span>
       {% endif %}
-      <span id="social">Follow us on <a href="https://plus.google.com/116964084929843019106/">Google+</a>!</span>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Google+ is no longer available.