### PR TITLE
feat(nextra): add git history for last-modified attribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          # Check out history for "Last Modified" markers in Nextra
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:


### PR DESCRIPTION
Having the entire history for the git repo allows the Nextra framework to assign the Last-Modified markers to each page so the user can know how fresh the page is.