### PR TITLE
chore(pages): show deployment on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [develop]
   pull_request:
     branches: [develop]
   workflow_dispatch:
@@ -56,7 +55,7 @@ jobs:
         run: pnpm run build
 
       - name: Deploy to Cloudflare Pages
-        if: github.repository == 'connectbot/connectbot.github.io' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.repository == 'connectbot/connectbot.github.io' && github.event_name == 'push'
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_TOKEN }}


### PR DESCRIPTION
Pull requests didn't have access to the secrets which is okay; just try to deploy on a branch push instead.